### PR TITLE
App now takes photos from a specific sufolder in the pictures library instead of the entire library

### DIFF
--- a/SecuritySystemUWP/SecuritySystemUWP/Storage/Azure.cs
+++ b/SecuritySystemUWP/SecuritySystemUWP/Storage/Azure.cs
@@ -51,6 +51,7 @@ namespace SecuritySystemUWP
                 querySubfolders.FolderDepth = FolderDepth.Deep;
 
                 var cacheFolder = KnownFolders.PicturesLibrary;
+                cacheFolder = await cacheFolder.GetFolderAsync("securitysystem-cameradrop");
                 var result = cacheFolder.CreateFileQueryWithOptions(querySubfolders);
                 var count = await result.GetItemCountAsync();
                 var files = await result.GetFilesAsync();

--- a/SecuritySystemUWP/SecuritySystemUWP/Storage/OneDrive.cs
+++ b/SecuritySystemUWP/SecuritySystemUWP/Storage/OneDrive.cs
@@ -51,6 +51,7 @@ namespace SecuritySystemUWP
                 querySubfolders.FolderDepth = FolderDepth.Deep;
 
                 StorageFolder cacheFolder = KnownFolders.PicturesLibrary;
+                cacheFolder = await cacheFolder.GetFolderAsync("securitysystem-cameradrop");
                 var result = cacheFolder.CreateFileQueryWithOptions(querySubfolders);
                 var files = await result.GetFilesAsync();
 

--- a/SecuritySystemUWP/SecuritySystemUWP/project.lock.json
+++ b/SecuritySystemUWP/SecuritySystemUWP/project.lock.json
@@ -4612,34 +4612,6 @@
           "runtimes/win8-aot/lib/netcore50/System.Reflection.DispatchProxy.dll": {}
         }
       },
-      "System.Reflection.Emit/4.0.0": {
-        "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Emit.ILGeneration": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )"
-        },
-        "compile": {
-          "ref/dotnet/System.Reflection.Emit.dll": {}
-        },
-        "runtime": {
-          "lib/netcore50/System.Reflection.Emit.dll": {}
-        }
-      },
-      "System.Reflection.Emit.ILGeneration/4.0.0": {
-        "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )"
-        },
-        "compile": {
-          "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {}
-        },
-        "runtime": {
-          "lib/netcore50/System.Reflection.Emit.ILGeneration.dll": {}
-        }
-      },
       "System.Reflection.Extensions/4.0.0": {
         "dependencies": {
           "System.Runtime": "[4.0.20, )",
@@ -8159,34 +8131,6 @@
         },
         "runtime": {
           "runtimes/win8-aot/lib/netcore50/System.Reflection.DispatchProxy.dll": {}
-        }
-      },
-      "System.Reflection.Emit/4.0.0": {
-        "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Emit.ILGeneration": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )"
-        },
-        "compile": {
-          "ref/dotnet/System.Reflection.Emit.dll": {}
-        },
-        "runtime": {
-          "lib/netcore50/System.Reflection.Emit.dll": {}
-        }
-      },
-      "System.Reflection.Emit.ILGeneration/4.0.0": {
-        "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )"
-        },
-        "compile": {
-          "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {}
-        },
-        "runtime": {
-          "lib/netcore50/System.Reflection.Emit.ILGeneration.dll": {}
         }
       },
       "System.Reflection.Extensions/4.0.0": {
@@ -11710,34 +11654,6 @@
           "runtimes/win8-aot/lib/netcore50/System.Reflection.DispatchProxy.dll": {}
         }
       },
-      "System.Reflection.Emit/4.0.0": {
-        "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Emit.ILGeneration": "[4.0.0, )",
-          "System.IO": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )"
-        },
-        "compile": {
-          "ref/dotnet/System.Reflection.Emit.dll": {}
-        },
-        "runtime": {
-          "lib/netcore50/System.Reflection.Emit.dll": {}
-        }
-      },
-      "System.Reflection.Emit.ILGeneration/4.0.0": {
-        "dependencies": {
-          "System.Runtime": "[4.0.0, )",
-          "System.Reflection": "[4.0.0, )",
-          "System.Reflection.Primitives": "[4.0.0, )"
-        },
-        "compile": {
-          "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {}
-        },
-        "runtime": {
-          "lib/netcore50/System.Reflection.Emit.ILGeneration.dll": {}
-        }
-      },
       "System.Reflection.Extensions/4.0.0": {
         "dependencies": {
           "System.Runtime": "[4.0.20, )",
@@ -12393,7 +12309,7 @@
       ]
     },
     "Microsoft.CSharp/4.0.0": {
-      "sha512": "/q7Wo1eEf1Nv2cuOO5h1F/MzEM0xn0MoV2kb1YpgDZFYZ/y5gkPYUA0Ws6mVADJKiMWnl2/RXb87roVhUy0QXA==",
+      "sha512": "ek68kIMAeEIpiK82SkIO6A6fLg3NY5ho306ijHl8HrIcgyaRzn2+yX+tIxkHL/Uq5TwWn2EhbLq+2V5ofrdcjg==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -12429,7 +12345,7 @@
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/2ac4ea902ef04f8faa81d43fede0c9af.psmdcp",
+        "package/services/metadata/core-properties/26d8d2189faf4722996fa271104b1c2a.psmdcp",
         "[Content_Types].xml"
       ]
     },
@@ -12520,29 +12436,29 @@
       ]
     },
     "Microsoft.NETCore/5.0.0": {
-      "sha512": "YC1CpPMNP4gxBA9h9Pt38/MCrDS5sk4fKivp8w6tGmmrMAIi+6Tc/z2jGYOfyy9wpdP+wQIrc4NqxxQt0ZGDFQ==",
+      "sha512": "QvapvB4CvDDLYpN7xeV8dHYrB5GesDpEHu7PxgyJ6serutt+sp5JXigPbri2ygpRz+vvIG1Ac3M4qORyuJsziA==",
       "type": "Package",
       "files": [
         "_rels/.rels",
         "Microsoft.NETCore.nuspec",
         "_._",
-        "package/services/metadata/core-properties/5c19426597284132b9add3c9a9bb9a0d.psmdcp",
+        "package/services/metadata/core-properties/8fe1dd90c9ac4cef8282bd7a41cffd4c.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "Microsoft.NETCore.Platforms/1.0.0": {
-      "sha512": "dOChpTfpqF9s/cKXqMTfl6fzwlcKr0BAD0g1OW7q/y4aJMVuK2U3MG4z7/gQ5zcMWdh26wG1ndMcMTTszozYxw==",
+      "sha512": "rzZy74xWhF7qnkM20rGRN6ZGfCi1uFni6t+5BApjYyLHHI6cwXGikzBhAZ54Vb1qbqETVt2NrTwTd/qDDvaK0A==",
       "type": "Package",
       "files": [
         "_rels/.rels",
         "Microsoft.NETCore.Platforms.nuspec",
         "runtime.json",
-        "package/services/metadata/core-properties/9c8a94967b9c49ea93dfe88dd697e984.psmdcp",
+        "package/services/metadata/core-properties/cb27f3417ae44d86a32d013b3c57f71a.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "Microsoft.NETCore.Portable.Compatibility/1.0.0": {
-      "sha512": "xyA/3viCYlKD9D9NIkOeVCk/4XZG6JU5mWtbAcPMM96L10Z9pODQoAmCTSaqTXcFcZdyzonDL5JRXwMVHasC2w==",
+      "sha512": "KgBMkstcBDtyKWofOn+fglu/An4qMAK/lMzHJR0Fl5x6Tv359Gyc+nRmSU6Xmjx5hkuYFpystL//FKHGs+UsXQ==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -12618,23 +12534,23 @@
         "ref/netcore50/System.Xml.Serialization.dll",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/68e2e8cddd2e4eac8589ff55eff940f7.psmdcp",
+        "package/services/metadata/core-properties/3f622d393d2b48eaa62652717aed8d4e.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "Microsoft.NETCore.Runtime/1.0.0": {
-      "sha512": "WLGNy01irr6GbZsa2cgwcXFo1xBnwl2xA1WLz9C5PrcCHGQQTQZhrXlOWxDKMVLm95+1LYCOmFU2t9E0ZEwz/A==",
+      "sha512": "CcbfLO4OPBRtVGWIl3cmiJzmrKz/PfiVbqsveYIUZXyyDj7IURQFe94uAqdc9YNBNQEp3dF2rv/6fwurpnqmdA==",
       "type": "Package",
       "files": [
         "_rels/.rels",
         "Microsoft.NETCore.Runtime.nuspec",
         "runtime.json",
-        "package/services/metadata/core-properties/130a0e13ca08468796e97132f5e44245.psmdcp",
+        "package/services/metadata/core-properties/96664f237f6e49c0b6767ecc1bc65ecb.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "Microsoft.NETCore.Runtime.CoreCLR-arm/1.0.0": {
-      "sha512": "h3aGSDA8QUidg++JGFHobZY//pkw4ZytaqdegEELIxr78JihDgguXY82kuSjymGgRUX3dEa2vJjB4vZJ08KMMQ==",
+      "sha512": "/Nj25wm/u15D7McwqmudWau1Lqe2azsQaVVB+//RcHh1aCAlvrW49tMP4R0gUa6SDgnXpxdvTiDYuioiL0k4Eg==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -12648,12 +12564,12 @@
         "runtimes/win8-arm/native/mscorrc.dll",
         "runtimes/win8-arm/lib/dotnet/mscorlib.ni.dll",
         "ref/dotnet/_._",
-        "package/services/metadata/core-properties/6f3415e22ba648e7bddab6e15b86e8fb.psmdcp",
+        "package/services/metadata/core-properties/df08f1e0eb0b472e807a2cb00c4e8405.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "Microsoft.NETCore.Runtime.CoreCLR-x64/1.0.0": {
-      "sha512": "4uKch6OiiZ1tEJZgAcbI5SW1upwPGHeGLMaALmx6xbWClR1KA2Y908vDdURWs/850cacr4l1nSM+KKwX4ZjW0A==",
+      "sha512": "X0ne1DcUdmdOPuM1WBXne9aW3+nGdpVuN0eErjC1hj1cTy16L4Uo9OlTKcd9k87RJvohQP/SSbCJ3Whw6ZGgJA==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -12667,12 +12583,12 @@
         "runtimes/win7-x64/native/mscorrc.dll",
         "runtimes/win7-x64/lib/dotnet/mscorlib.ni.dll",
         "ref/dotnet/_._",
-        "package/services/metadata/core-properties/4d0fefaede4846a3a391bd5abc0b310f.psmdcp",
+        "package/services/metadata/core-properties/dd090f56e7c648da94a94ddf27b2e399.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "Microsoft.NETCore.Runtime.CoreCLR-x86/1.0.0": {
-      "sha512": "hG8Om+3GLALPvfoAFpU+cDgTm06iibolDkjQGI9AObZ6bBuD44t71KSvtOLohEFbxgqS86UnVjxys2mB4dU/Hg==",
+      "sha512": "cdvDtwggMjzTBuW8o0FA0R5egKz+Yiz02T3CgtubmIrQNX8SFDnSJMINNeTg8OmH0dJ+/XxUu6ZBKl5lXl7kAg==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -12686,56 +12602,56 @@
         "runtimes/win7-x86/native/mscorrc.dll",
         "runtimes/win7-x86/lib/dotnet/mscorlib.ni.dll",
         "ref/dotnet/_._",
-        "package/services/metadata/core-properties/b8118c0be4ee4df4a07d0072a904f7f6.psmdcp",
+        "package/services/metadata/core-properties/a2453af8999848c5ad2fbae166a301f6.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "Microsoft.NETCore.Runtime.Native/1.0.0": {
-      "sha512": "YqSBF9fB6NEdaIikdGi6Bo8pGYh4E9j75+bXv7yiFjaSHZvCItQ++Q7MOpGYWVygavwI4Gji+rFd+oscbi3HHA==",
+      "sha512": "3B/pScOAjMHgS8A5KaWXrhMCJGeOTJ32b4PkkIpIC8o6ydXcwfpw9B2uhwGi62RmQqIVcf1D4Yg3AbVr/f3kVw==",
       "type": "Package",
       "files": [
         "_rels/.rels",
         "Microsoft.NETCore.Runtime.Native.nuspec",
         "_._",
-        "package/services/metadata/core-properties/6f9a59cc7e304b7ebd52522cba68f725.psmdcp",
+        "package/services/metadata/core-properties/9be33e8ff28b4756bfba9ba5752876bb.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "Microsoft.NETCore.Targets/1.0.0": {
-      "sha512": "z420UVnxpVimjP/uOLpjHL8Ht5lundIw8n+/lcpXGKrscNM4tVaYS+fPqaVrVXKaEh04aXbOSb2TSFA41AAB5w==",
+      "sha512": "F/ba75ldHaZvcmN4Z395PX3grX5iHLybgC9M3MvmOD4pLd22Cu4+lsBua87SxV96VY9dTRPq3Z3QWIlD7u5+rw==",
       "type": "Package",
       "files": [
         "_rels/.rels",
         "Microsoft.NETCore.Targets.nuspec",
         "runtime.json",
-        "package/services/metadata/core-properties/b474eae74684434186a205d6d6e82e42.psmdcp",
+        "package/services/metadata/core-properties/b93c4410b8ce44c8b2fce39cdf20a3a1.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "Microsoft.NETCore.Targets.UniversalWindowsPlatform/5.0.0": {
-      "sha512": "C5pZvgwjt4aLXGcqHxKi5JahwKOb32FJUPB+i8QAuSr1J4XXXNvEoY4bcrXcFWh1DyeQi63BSyktTFEY0yYSZw==",
+      "sha512": "vI7MbqanupF6CwQvpRreYv0XC6NLqptP9MP3kNnd/CetDo06H554ElP0cFxGeor3bwDG04Nz83ZkoOGQPMy54w==",
       "type": "Package",
       "files": [
         "_rels/.rels",
         "Microsoft.NETCore.Targets.UniversalWindowsPlatform.nuspec",
         "runtime.json",
-        "package/services/metadata/core-properties/ddd92b7116d4441698a13b69b4de06c4.psmdcp",
+        "package/services/metadata/core-properties/7f6f39c7021946a7b7d2beb09eb03077.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "Microsoft.NETCore.UniversalWindowsPlatform/5.0.0": {
-      "sha512": "gcmbRUiypZblyxgxJgmP1dKLfOkvyxEmIF/OtjE6KyRE78PN4RNAoI57kcWPWwBRspWHOnn8qExtMqzjzaLgsA==",
+      "sha512": "+TIwYgh+XqK0bGe2BW2lhMPlAC0fUMpg+RhdF2y5fPyRU8EZJWg5AAOgGQI4YSzmOJ/SCNpreaFDB7ChCHX2+A==",
       "type": "Package",
       "files": [
         "_rels/.rels",
         "Microsoft.NETCore.UniversalWindowsPlatform.nuspec",
         "_._",
-        "package/services/metadata/core-properties/263a7dd951ca47f38a9204cd8667e650.psmdcp",
+        "package/services/metadata/core-properties/ab7b3e4899f34e7caa004ac470957d64.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "Microsoft.NETCore.Windows.ApiSets-x64/1.0.0": {
-      "sha512": "rMmhVSsVGrq1Rq5QDeNj0Qmn5ogGpEQXekIkWTRRJdI8uB3kdf5Z5DdjezeNAjS3nj+9+zn9ESvdeYyPdvGQQQ==",
+      "sha512": "bZUkkHlidRciKe+dv20qX/2wtFJY3yqks7AcuhtPKbNzo2BZFszUci8o/nwhzxS5LEBjEzpQRT8/VqVAt/fi/w==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -12897,12 +12813,12 @@
         "runtimes/win81-x64/native/api-ms-win-core-sysinfo-l1-2-3.dll",
         "runtimes/win81-x64/native/api-ms-win-security-cpwl-l1-1-0.dll",
         "runtimes/win10-x64/native/_._",
-        "package/services/metadata/core-properties/6ed26c026ec74779a1e31cfa0807e317.psmdcp",
+        "package/services/metadata/core-properties/2e41b08eeb6445e083fca9fb8f7d6133.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "Microsoft.NETCore.Windows.ApiSets-x86/1.0.0": {
-      "sha512": "pLMpE6xJvxHdU/GAl+TdsMm5mWR/rsmXPIkXNzYFeYo1HuQ/8ueSBlOFBJwQfsawHRG/DffVEaD1fNZyaQvYNA==",
+      "sha512": "I09wW6KFkQqbYM0qro07LczeD/lp73LTITu0h7tjqJjOgA9bnCr1DOFtgo7DcSquQdtMpV7tQWzDBiirDI8ozQ==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -13064,12 +12980,12 @@
         "runtimes/win81-x86/native/api-ms-win-core-sysinfo-l1-2-3.dll",
         "runtimes/win81-x86/native/api-ms-win-security-cpwl-l1-1-0.dll",
         "runtimes/win10-x86/native/_._",
-        "package/services/metadata/core-properties/2a60b1220c43441a8818df7ae64c8b76.psmdcp",
+        "package/services/metadata/core-properties/573231c0f6064bcfbb71c76a119dea90.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "Microsoft.VisualBasic/10.0.0": {
-      "sha512": "KtE8IcXhBfGYCvOcNE3BUTowgwqXhbJxJO6Tn1UIG8WBeDopIf+ygpsGI3rFt7cycvGbuS1+zWUGnmBKdcSPMw==",
+      "sha512": "VZ5ABF6c4b4s+gKynoI3gj+WQg7R0PR2ssRyuWURPgfkWgghnG8+7MrgDRLqhUqZrC28rABjKNtLxgTLbbCE8Q==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -13095,12 +13011,12 @@
         "ref/netcore50/Microsoft.VisualBasic.dll",
         "ref/netcore50/Microsoft.VisualBasic.xml",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/36ec6801501a45209248459a0953ef80.psmdcp",
+        "package/services/metadata/core-properties/61924f7a57f146068bcf766645719546.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "Microsoft.Win32.Primitives/4.0.0": {
-      "sha512": "WM3QrH2rfd/9hj7J/IBC04hjKxzlPg9JqchHSiVxSHVe+d+QpM8Aw7w4q6bhm7mrFhyW/BgX51bfr8TU9Hjo+Q==",
+      "sha512": "b/+Fw8M6dS9GjXvPDMM1ozV4qpCIY+wqpFjzvE1X9iJIxS1Z7Zipiakc9ajl8D9m8hFKLTx+w8ICpZHshfJXnw==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -13127,12 +13043,12 @@
         "ref/MonoTouch10/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/519ac46891b149da9e3021b01ce40cde.psmdcp",
+        "package/services/metadata/core-properties/ced988f10db64550a9e47ec4ceed5fb1.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.AppContext/4.0.0": {
-      "sha512": "MAAI7lkOGRc6puP9ZEGaLF5ToBbwBWnPk0UUojElSCfQ9JyPmDeqCbuUhjkvzENo8SduSO3ePz6EyQCRvKxjZw==",
+      "sha512": "hVit3QOXkIacKbG+XYDmwXP+2Po541qLD9xtoDjb1nEJ8lEvgkToxLwDpUln3EplRo55HLqAvKlKrRXBSTkQBQ==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -13160,12 +13076,12 @@
         "ref/MonoTouch10/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/655416029fcd4217aa3d84354108cc57.psmdcp",
+        "package/services/metadata/core-properties/b238a6e5d5264c809505b171a2c2ae46.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Collections/4.0.10": {
-      "sha512": "G+toQ0yP+OeP/4OoNZoS6pY4OumnLQxogIotGVnNAzBzlAysQ1/nN/QKkKz7cbjsl0j9rSG8gO6VBrRNfl3thg==",
+      "sha512": "QuN27OxpnrZ4vZ0J7adumpdnlWoAXidz9g8OtrD2KYW6+WfhXD2+TLQynuvFvv23wYii+Nb9KjQ+UL6ptYBAXg==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -13194,12 +13110,12 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/ac9c7722031241b9bfcf76a298a5d2cf.psmdcp",
+        "package/services/metadata/core-properties/4f66bef155a6468a9ddec6fb1c41a396.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Collections.Concurrent/4.0.10": {
-      "sha512": "CeIYWNXnFKCo2RP/cGupUPA0qi8BjUQn5L8Jd8Bc2+1g/+crKGiwl+wU6+i0LuSubQCC0V484vBvtBAjQhn2aA==",
+      "sha512": "uh8GCdgkHjYDysu0ZSpDMzL6Aq4jZK6Oos3bSwzlzJE7DITwyBMWoKkjHYqtUi92M4GcNT+7lmliFYVAzDJFOA==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -13226,12 +13142,12 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/48b38705af0d4bbb9c868ab1b8431c40.psmdcp",
+        "package/services/metadata/core-properties/c8db86fd18c241b499a790afa7fbef5b.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Collections.Immutable/1.1.37": {
-      "sha512": "yd3a6w6dGlYc2HV8m1RNBvZRY5g5sJeci+zrHab7i2ZXlyuLA22ruBAw9Cklh10bCZ1sNR+zgQR/1QXrTw+U9A==",
+      "sha512": "l785FJiwIHbjto9f9Pxaai+5baykJejIf8GbFDSncSyd4HudkfEFi4p5g/Uvs8OUykjHbIrd8/uf2buIRk93DQ==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -13240,12 +13156,12 @@
         "lib/dotnet/System.Collections.Immutable.xml",
         "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.xml",
         "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll",
-        "package/services/metadata/core-properties/cbed47750633453193a8c9b73094d832.psmdcp",
+        "package/services/metadata/core-properties/6d6a38fa0eb44ebfa25cbec75e232e7e.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Collections.NonGeneric/4.0.0": {
-      "sha512": "riqYXUiQwwDO82YCFxuoRDh+7lsA3cAxWxCkyuSHfusMAiuMrFHCyGfDpWQ6iH14BrupzgHyE89/Xlg/Usf75w==",
+      "sha512": "hnBvmIFKguXH35jllSqqYS+R+dgr8dL6+V1JJi12YvbPR0mISyKfyFhSSBrZodH2CQlP2bz3EngspClaX3pHaw==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -13272,12 +13188,12 @@
         "ref/MonoTouch10/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/7be1bb283c124c6fba5b24b875562876.psmdcp",
+        "package/services/metadata/core-properties/913460b1af384d1290654b650e916dc2.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Collections.Specialized/4.0.0": {
-      "sha512": "DHWBV24iMkk7F74jKxKzEkCzTTL8fPX/BqwtKLaBVs+iYQE1SvXxilxPeYrs0Yil0Bh5+le3ZlBufmsFhUkkUQ==",
+      "sha512": "pS2zO99AoeXUAVkWn4dOf/zozk/DNLIwVsRt4R03VMv6Wi372qJkrFWwgv5v6nHhGh7mJsC9Io8RWsf6pZsa+A==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -13304,12 +13220,12 @@
         "ref/MonoTouch10/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/cbc8d683b6d0419abe14f23346262461.psmdcp",
+        "package/services/metadata/core-properties/d7e865b2b6cb453ea5a7400d3c7815a3.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.ComponentModel/4.0.0": {
-      "sha512": "P2BJARZiQ/SJ+wT8qo9sc5kNMooTADLfwvYbXj4vGh7EV4Nf8B2j6Wgw2PxSXoL57y2Tv4FwN/1fcyY80rZa+w==",
+      "sha512": "q3hYt7xoSBLfIIPnByInW152E8QATpjv9zlJKZNdppbLHi6wRUY2A/ccsXmT2MfoHCOGNb6zojS5bdjkzTH3yQ==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -13337,12 +13253,12 @@
         "ref/netcore50/System.ComponentModel.xml",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/c8fe56097dc94e2692e00b67652001e9.psmdcp",
+        "package/services/metadata/core-properties/007bace5eee6466d9e11a400b8ee3439.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.ComponentModel.Annotations/4.0.10": {
-      "sha512": "97Npx/OAmKtGCbPjHBjYCC3LYIq+esUnyF3IabA6mvNi8b1j9xYX8qw0az/3KN1pHRRJubiAVvQs8vuWLrJQ2g==",
+      "sha512": "Lgp14ct0Y12ugzr23aNSuufA7qhKcQRBH4bYVHiNrLl5Pbak5zW57WscwZxK3CC+jQMurpO26s43+vTCa61ehw==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -13369,12 +13285,12 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/a85323f2882a446eaab7b8d4a66ac523.psmdcp",
+        "package/services/metadata/core-properties/721f2a9f888148a0a03269b990ba53fd.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.ComponentModel.EventBasedAsync/4.0.10": {
-      "sha512": "uMJi43QVmH0rSxFUbHq/4EevO0OBe9hz3ScosDruKnk4r6y4mZudzCxu5VWn5+k5qa+gbTHb45d1RVnDqJLlug==",
+      "sha512": "4aoQjy09/e4XdgMSyvoS7q210xchJmEZwQFFlFb6zBX4twAtXJuYb/woGK2R5mk1k3wULiNgy+UC13/GymM3vA==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -13401,12 +13317,12 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/fe5f603f0b634abfb786db1edf0ccff6.psmdcp",
+        "package/services/metadata/core-properties/618818b3be9c49a0982e08f8301bd6b7.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Data.Common/4.0.0": {
-      "sha512": "Euk8ArZkEZRif+eKdfimEyIS+X9sRuQJrS2oLeqfycLmWEaSISRLm9S1xxV2QnaQS9qeGahfXE/RDU6rYj2OeA==",
+      "sha512": "xEdZn+vxF5qF+0Ji59Ag31L/urJgUZx+JdJTyJW1z0nFsOV0x4lyfAgu2gxz1PzGFGEc24ZiGpxUtXOwZrdybw==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -13433,12 +13349,12 @@
         "ref/MonoTouch10/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/fa7dabd358b54aacb434863246f6efcb.psmdcp",
+        "package/services/metadata/core-properties/bb498de08879432098e90cbffe5c9b3e.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Diagnostics.Contracts/4.0.0": {
-      "sha512": "sEa09qL58PrTuOfARrfSw07J23fuxnvwPV4JkHsToY+++ApbF5ErQRtGz5kl97/vwCQUtxLvCIu5TuUKkbBqag==",
+      "sha512": "zJKjXn2Wvy6TE/Qb8K56wRfDIE5TGr4x8mm0+HUVdRnFrVjfEo3Ru0nEv0NsadILXe0mPehaaPZXu//VNgsYDg==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -13467,12 +13383,12 @@
         "ref/netcore50/System.Diagnostics.Contracts.xml",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/3bb089bb140d4eab90594116d1a84885.psmdcp",
+        "package/services/metadata/core-properties/7c00bfddff3c47babcdefe2a30be59f1.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Diagnostics.Debug/4.0.10": {
-      "sha512": "3hQHgjaio4VT69P/RZq5CA9V454I37H7XkwViR4smCsK4jeTgq+bQI7/vS45ZNTGUn97t9tCBPZOwC8AFFECLw==",
+      "sha512": "WSFOKtxnXEAtNSClHsf8cdaELaKl8Nnxnclum0Cu5XJnXzIZcefJAV2qbv5mQ+OEBJ8uscJjN3KfEopG/bUEqQ==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -13501,12 +13417,12 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/d3937ee60f3f4d09943e79f2e32a2c9a.psmdcp",
+        "package/services/metadata/core-properties/a02b987ad5c94d39a4c97b42c42b5aeb.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Diagnostics.StackTrace/4.0.0": {
-      "sha512": "RecUY9dpaj9oAbgknEviNCxNyb6Y470JZfeYsFgnnD5H+kLI0EoJUFDere31C4p+niaszfY7lL4qItsiZQC5og==",
+      "sha512": "mmJcfs0wV3Bqt8RydICsQx96apbHe+XnM7H7FmFqCXBpxwJi6cJ9gT4Jp3ZI4bstO3cZmLxv6kkuH4DjliWgTQ==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -13535,12 +13451,12 @@
         "ref/MonoTouch10/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/07ae6262c00549169137f620ed7dd0d3.psmdcp",
+        "package/services/metadata/core-properties/cc97a55b43bc469daacf189dcd14a784.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Diagnostics.Tools/4.0.0": {
-      "sha512": "ukmw+WIDKlW/ymnnAn9VUdeO7xPG2QjMjPA7RRA7TPm6FVDzQyt5WLaaHKTotsbRbdWmYEmNMJHsXrrrTnux2w==",
+      "sha512": "Mzp+1SKiM17TCwVKZ5sqdwQjEGEK95TIcEbr9k7l+/TKmLWGJtLVXAiE/gOnRtcJNmMpro7lFhfm1fH7XkJyCA==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -13569,12 +13485,12 @@
         "ref/netcore50/System.Diagnostics.Tools.xml",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/c256d7d920814e87aa8be3637f9aedbe.psmdcp",
+        "package/services/metadata/core-properties/4e563a7dc08b4ecc9c40f10dc8f473bd.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Diagnostics.Tracing/4.0.20": {
-      "sha512": "mSlqpxtVNaEl/Fuymwjp9jGvjHb6+FNTUI+LQwBH1WFWy6S10VeXvJwokOC71FmYdbl+Cdyk0OGlVE6YXYa8dA==",
+      "sha512": "f+SqGRkD4OTgXadX6EJC0jYQ1gYhAW+4m+G8rkuGizASRvXtl0YMWf2rPbOYXGGoL5QzYUvp+Ggd2iI0i4l/hw==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -13603,12 +13519,12 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/c747c51774304ae69103509c90e50186.psmdcp",
+        "package/services/metadata/core-properties/eb7d9d9717154e03ae6cd7875edf0883.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Dynamic.Runtime/4.0.10": {
-      "sha512": "k3fwDFybJA4Suar0164ar45UZZBdyJR3u2vY/baEX/syoVm9boThITUJ8PPTGqMDKkQiqtJxH2qmIcu6/A2k7Q==",
+      "sha512": "2oZhLh+QwpaiMGAYbTgQrMs+NQzdM2tmfR8Zm5JI6bqh6fN+czRhxnBw4npc4asO+Z34pHdXrmMZGDtQh8byKA==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -13638,12 +13554,12 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "package/services/metadata/core-properties/abfcc357a8a745d4b3aa049e49f6edf3.psmdcp",
+        "package/services/metadata/core-properties/eb6cd986dad44438baa776afe9363231.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Globalization/4.0.10": {
-      "sha512": "jTWDiuUyrWxvYToTPUHAu3HhZxsAgrlLWyk7TxpLI3Xhi0zsTPiyaljOOmDH6IyZjaJgYkT7tEwU2dYZixxCiw==",
+      "sha512": "9hqxzl3P+epeE68b/1yFBgBs+QLm+KUodjcR9tu96GiFW5vK32joN6argZ2oHVvQkcOVTm1aV6v9KpTCLMb8ZQ==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -13672,12 +13588,12 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/1d0e237bdf4247dc8374d6875795bd4c.psmdcp",
+        "package/services/metadata/core-properties/55d980910f5246a6ac06973702f64df5.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Globalization.Calendars/4.0.0": {
-      "sha512": "nHK2XkMVQE8o4359SdEKTzyTYYwOOXsMRDsNBMSWjitxL8jK8C2zXpf5yrL1DEz68MRY152ONLtQ+Hfla+6DBg==",
+      "sha512": "Rtl5bQ2KSuB8oXQMx0pVlBCBlDeGz/QuvwqGz1HWET26BGXhb/6j5cXetZydrx++hPttndndI18CsIbAgBLikg==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -13706,12 +13622,12 @@
         "ref/MonoTouch10/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/75d6521437734eb3af6d9c4b212f783e.psmdcp",
+        "package/services/metadata/core-properties/88aa273db8b84eb487819bda80bb5573.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Globalization.Extensions/4.0.0": {
-      "sha512": "pPws0NUeAzOrrvAeZLXNBYU+spPE8q/EhVbPjaAgROpHZps2Njq02TNRUosSwYhZcp91GsVqa3AyzC5fajPc2Q==",
+      "sha512": "kQn+7Y5tmMWYpnPzi/ljvyLhTKojVZUtb7dq9bEUaRedoq8c0QgmUL+fACW9ptqUha5LQJUQaVm3Wy5rPx+lFg==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -13738,12 +13654,12 @@
         "ref/MonoTouch10/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/7f76a26b53e344c68dd3167f7342037e.psmdcp",
+        "package/services/metadata/core-properties/af1f576bb2554756aab1de476dc8b8f4.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.IO/4.0.10": {
-      "sha512": "b+unKeiPlPaS0uCNSZ7Zh/xRHgBWKGgYWs+Ti/MdYt6eZ+xzIjNCKgzFih3WCwndzHEp/+Lju8HISNfBsQ0Zxw==",
+      "sha512": "RaY+kp127vTg8JTHmMwEuMnMprJTQlkvfsZSVSR6qU0HxWk9LwsEra5HKVAX5bS7OX9+KWCWXcFbEZaz5U7QLQ==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -13772,12 +13688,12 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/5bdb8750256649919b9ba105fa95063c.psmdcp",
+        "package/services/metadata/core-properties/f7570f124d4e4d7883cd2ad40c0c48bb.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.IO.Compression/4.0.0": {
-      "sha512": "0UvH3ZGKby7nE1uaeiHb7lgRdT5jMkKOP4vSFdxylhRnUKsq5Dl3kw7gc4XuTmdpqL/khwTmSM6YDMWv0T1+UA==",
+      "sha512": "U1+YhU+MDxtQpjGJktODG3jijXueF1jUYrZPHEP6LI+m5Cax0lsAtMv1PsSwZ9c6KPtNDMM0j/SBBOX2YCyRkg==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -13812,48 +13728,48 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "package/services/metadata/core-properties/306e00d6f2584541ac675749670d3449.psmdcp",
+        "package/services/metadata/core-properties/6cd62877cb804294b5c8d1d89d181edd.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.IO.Compression.clrcompression-arm/4.0.0": {
-      "sha512": "NMf6nOnXRWzQRXHJI5Mw16nDi9j1VFNK/V7SFMia7S8gAK6dUXnOMcRkqUS29qkOnjUtGOB8DXI0WA4BP/Jzlw==",
+      "sha512": "GSzad/6RQBuAU22l0iULppMdF7xcHz+cW7psOFNPwUbWQfQAK3hfpe4Y7acwS87O/1IVrtN7OeUMTEt2Wy6sXQ==",
       "type": "Package",
       "files": [
         "_rels/.rels",
         "System.IO.Compression.clrcompression-arm.nuspec",
         "runtimes/win7-arm/native/clrcompression.dll",
         "runtimes/win10-arm/native/ClrCompression.dll",
-        "package/services/metadata/core-properties/ef5a9c99ba24479084226ed030316f2a.psmdcp",
+        "package/services/metadata/core-properties/274dd5357f8946518736d0c8ae0703cf.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.IO.Compression.clrcompression-x64/4.0.0": {
-      "sha512": "RibRRZn7DBhdcRTA5Gmu8/Z2jCQVPQFjFooesqC6V95k6xjDMqQD3RlOyA/yVS2oADaACV1qtdhIjLWaEQ+NUQ==",
+      "sha512": "cDEtbRJgIiX+K1aknugAS385IlIUS8FIprOCcD4kToZ8XAeFjwg6lsjQWA/Vc47bzNxwehsXMdigKVTT4yT0oQ==",
       "type": "Package",
       "files": [
         "_rels/.rels",
         "System.IO.Compression.clrcompression-x64.nuspec",
         "runtimes/win7-x64/native/clrcompression.dll",
         "runtimes/win10-x64/native/ClrCompression.dll",
-        "package/services/metadata/core-properties/0a093359e13d4e2a9a3d2a6378979665.psmdcp",
+        "package/services/metadata/core-properties/e74f5e8264514bbb96af936b1df33f08.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.IO.Compression.clrcompression-x86/4.0.0": {
-      "sha512": "dws2DwhfIQ7XIhsIWhsgicwUvkXZgNGwA2uYvG5X3S+rLWJ1H/+x51FlUXXHWihGOVDfA+WE6ewaQKxODqM/5A==",
+      "sha512": "MCLH8J96iUJht//QZl4KzWvnGdRFRB6RNt44IP9wluUd8nVYzxPf42XBUxslPsvfmuxvyFUaNj2poeOva55xSQ==",
       "type": "Package",
       "files": [
         "_rels/.rels",
         "System.IO.Compression.clrcompression-x86.nuspec",
         "runtimes/win7-x86/native/clrcompression.dll",
         "runtimes/win10-x86/native/ClrCompression.dll",
-        "package/services/metadata/core-properties/9133927234b843ef8d7719ef4bedbd2e.psmdcp",
+        "package/services/metadata/core-properties/876f34c679b34cac8d11d25f25798c2a.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.IO.Compression.ZipFile/4.0.0": {
-      "sha512": "VBBh0ibi0ZdOWHERwK/MYC7LpMm69aE1uFEoFyEFFplWObd6G7QL6x7iZXlK4zYqR8X5tg8LhMatcAawUMjlhw==",
+      "sha512": "o1TRlzwHcCDQgXLGaPNgRPaNpg+SRLTx7tOKHLo+WrN/VaS0m9zo8PfAaOCE73e3QnUI/taXGljHZk7reR3M7g==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -13880,12 +13796,12 @@
         "ref/MonoTouch10/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/46ff1f5e213b44c6a667f6af5102a079.psmdcp",
+        "package/services/metadata/core-properties/257cf4ce7abe451590265bffbd41a679.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.IO.FileSystem/4.0.0": {
-      "sha512": "QueD58wAm5iySBT+zioXc0D63uidMGxdPFJxquUbN6Tcsp4O+xXVatGMnOCg4WA3wo6p1G9vxZwn7xD+8sWmtA==",
+      "sha512": "3L7xJzc8DNvSdJ0Uv2ba3YyDPzHCEq58BxFt6KAMDDVgi5JC13i+K9NaglsPrs3DY2YJ8STjpYEnGtczN4+bfQ==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -13913,12 +13829,12 @@
         "ref/MonoTouch10/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/444f82a87d0b400b8067c51b9ac8b343.psmdcp",
+        "package/services/metadata/core-properties/f3207a24692b42c6a117f62417b6b462.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.IO.FileSystem.Primitives/4.0.0": {
-      "sha512": "gB1r7Gyubrk+v7au+mp5WM7/vm9yw3OGmETo3G8J9NuOZ68XjMljzZNtDCE4AmU0g9xtk5d5dPT+VVlE433RVA==",
+      "sha512": "FmepVK6eYTiA0nLWrhi6JpHhfEZZ7OiHA4G7vpPfUW9O6cwh9BrumF/UUFX83hxFnVqdMpToHTQ6ov8f+7DikQ==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -13945,12 +13861,12 @@
         "ref/MonoTouch10/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/54e4f036e33b44de93e8b89b2037ced9.psmdcp",
+        "package/services/metadata/core-properties/c4ff724dada44ca687149e2f36b8b5ab.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.IO.IsolatedStorage/4.0.0": {
-      "sha512": "JZwmP3++ghqPCm1+PAcOQtk7zZjLQQ+fyetc8ipVcoMt9DVyDqoxmHukI36tK7maycfoUftNaNgezYNT3Purmg==",
+      "sha512": "+RjE1VFywfGNe4hn6hli8+J+dq+/oh3NB98I436ENB/BJekAPMMp3e8MvrJMX+EGgGrM6q9BjQ5yW4X4pQc1iw==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -13975,12 +13891,12 @@
         "ref/MonoTouch10/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/f9b9a726a2fc472f884a9f7f945fc6bf.psmdcp",
+        "package/services/metadata/core-properties/3716e8e083444ead8e3220b94542b457.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.IO.UnmanagedMemoryStream/4.0.0": {
-      "sha512": "qm32tGSSvN0S9OoTyZjRi0qcu9CPV1Qm2KvIOL+f1WDS1wxW8Mp8SlKQ97L/t5FWpJQijLwuhTNTdS6bJDhmAQ==",
+      "sha512": "5zT3+Ukr04Xl7Fr7xm8Jsua8hMqnRQ4JeAPC5b17+jojDKtPufxtGKkvLWE+bp+LsCroRnOGkmiglmgIWXzO2w==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -14007,12 +13923,12 @@
         "ref/MonoTouch10/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/cf20262a861a490d8474ba5632a21300.psmdcp",
+        "package/services/metadata/core-properties/d25f3799997c41968032c2f2a2f9429d.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Linq/4.0.0": {
-      "sha512": "de5y6zZ1XzkixH04wuyj7o+0oUeGvq4B5F1voWhUu/isJixUfjoSpu2OVK+0+vE+2drFh4085NtVyz6pM6jdJQ==",
+      "sha512": "mDioNaUsL2jYfXNDSPb0sSW61kyg88mZSs9NCb2uIWEONueBRq+JCnh6gV9JDuVciLqqTwsDsoWBbahoEipDlg==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -14040,12 +13956,12 @@
         "ref/netcore50/System.Linq.xml",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/93bdeb6af21d4259927e4c747a814874.psmdcp",
+        "package/services/metadata/core-properties/c0aed90eb05b4c88affe58440dd01f74.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Linq.Expressions/4.0.10": {
-      "sha512": "SUMoj4NPl/KE9ezUKta8K4fz3YBJpAEAhlRodVNCN2HnhYl3/a0th/Si/ORLZ8/EbLK0DnCdJ4Co7pEdSH+9ww==",
+      "sha512": "fHbsAgaU3TjK88i2iFAxC9wRAAyd9gmKWHXAyndfVzBkdANVkIRqbHb+NALH3hKnPgsESPhIhcNWwfgVSf+BkA==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -14075,12 +13991,12 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "package/services/metadata/core-properties/c3c89b7953414a6893b3aa0e0c088df0.psmdcp",
+        "package/services/metadata/core-properties/46d29f4765354644af2af4ce64c8d44b.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Linq.Parallel/4.0.0": {
-      "sha512": "flofdjqj8o3znrTyYQKaJ9JfRSFvObIbCKxn0++lljHafxrzvt2AQ+ZMaO0Egj8jbg5Tlek4JDajhKK+QKQngQ==",
+      "sha512": "dNmjt6dvR4mka3CnuwfGAey+4NQANmI6mEUFGvyOu/Pi+z1in+Gj6mnpvPfY9q7EG2NZ0sUoQaV4/QTpAlO32g==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -14106,12 +14022,12 @@
         "ref/netcore50/System.Linq.Parallel.dll",
         "ref/netcore50/System.Linq.Parallel.xml",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/c2e652a04ab04f118c1ce03787a2893b.psmdcp",
+        "package/services/metadata/core-properties/ea1e4f606bd6452aac300abb754c2d20.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Linq.Queryable/4.0.0": {
-      "sha512": "Y3l+g9XAjIG5pyCaAuUuiwUdCLzKfcYX7O4sMRn4jbpQnGPm5j34KqIpB2Qjer/rAnlUfqiotaYpCeeAfAiUKg==",
+      "sha512": "boTMI7McyGRQX6fqHW1gFyKNScF7QJwYQl05XrQ1mzQpT+aFCZZGfp7Ue5jz1hu56XggKhVT8cmbn65Zk+bpRw==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -14139,12 +14055,12 @@
         "ref/netcore50/System.Linq.Queryable.xml",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/e029d40b28164639ab39118f5d7a25d6.psmdcp",
+        "package/services/metadata/core-properties/53d79f6f24084ee49bb141688d6bb759.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Net.Http/4.0.0": {
-      "sha512": "iaoR94Z3zuuVO5C2mZG3kVfTxWXA8UObPUe8TwKON2GvO6d/FWC+xF/0OrV7XdjrKdnhYBjwTwBRZV0Sx9B7mA==",
+      "sha512": "Ck6aXpEgvhp1XK5w4l4vtRgg0ssd6NEHNQ1+SqfF9AynvhpJDbFJmAJF9q04ZRCaRqlBMyzRv8zTWtBrfCvyGg==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -14170,12 +14086,12 @@
         "ref/netcore50/System.Net.Http.dll",
         "ref/netcore50/System.Net.Http.xml",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/719bda95ff694efaac791797bc4eff2f.psmdcp",
+        "package/services/metadata/core-properties/b32ea537dfa1407cb0a3284f27925ffd.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Net.Http.Rtc/4.0.0": {
-      "sha512": "5NRniWqva0k5Q3bmarrQP0demcutcUkLw9vkfcPJgtvzheZzB1aLTtXmGfxBTW0OzolvQmbdq3cteCQdpedzbw==",
+      "sha512": "FK49BicvB35JVMRWuWsxRJRZEYv8tIi5WKwgqqZYxm0BjXSvRMk7YpfPGtaNrnxCMemzwc0zS6OIiDcxhmEvUQ==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -14196,12 +14112,12 @@
         "ref/win8/_._",
         "ref/netcore50/System.Net.Http.Rtc.dll",
         "ref/netcore50/System.Net.Http.Rtc.xml",
-        "package/services/metadata/core-properties/f6d9f694b234476b9ed1c871629b293a.psmdcp",
+        "package/services/metadata/core-properties/f40a6920ac2640d685241fd0181f1c93.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Net.NetworkInformation/4.0.0": {
-      "sha512": "Hi1N9Ix89FMLI67I/yvYTqscLbXzuVOZ9RCRBWYYZ0T9nLnIaKzGExPAunNXIE6v275VB3po38CfJU+I6j86Nw==",
+      "sha512": "/jiycm3Rcm/b0EMHcA7S6Iezhp7RGO9PRqdxT8rq+MQ3h3X34eru7SJrZHIKhKbredvPEyGjFPjgXFI+4fwdcw==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -14236,12 +14152,12 @@
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/80c73710e52b4c4fbd3a6816ff6489c8.psmdcp",
+        "package/services/metadata/core-properties/394e71f3dd334b7285673b01fe26848d.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Net.Primitives/4.0.10": {
-      "sha512": "cPVSIgOVPiRVzYIX69+BuW5jLyOqgEE7PJMQgdi9CgdTJRL8piV5JP1y0EpOFp3cHI94Xr3+2hioHKOU+lhQbQ==",
+      "sha512": "NtHNVbmhJKXg7slFEpxI0n5Nd0Q4fNunU9vP47Y6SoThHCcj7eF12F88mJfey/63LU/qqPNUCkqqIjm/WNzWZA==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -14269,12 +14185,12 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/9a5b789873a8456e8747313478ca873f.psmdcp",
+        "package/services/metadata/core-properties/e5696d54562a4232aed17aab3ee6b735.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Net.Requests/4.0.10": {
-      "sha512": "l/9XyySV18bnZdcQXn4r4FDPozQn2mIm56PfUgkbu/XAHnvmdQ28bbKwWOEsjNDU8fv8v0UEnTJvjHCg8l0+Qw==",
+      "sha512": "X/unc7CA42MoIoKABWWN+EkmU2AZLpEAu6w45OL6XFVUPDIHXIVxkZKXJ8qtA7qfOW89+jicbfMMneDbOQxYoA==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -14301,12 +14217,12 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/1e24201df1c34934a97c087092fcff4e.psmdcp",
+        "package/services/metadata/core-properties/cbb3b0fa94bb49d497923e0056374d47.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Net.Sockets/4.0.0": {
-      "sha512": "dTO0NmDbz3pEMdrCUlQeSCL2P+I3veLOmOw1HxDvlx6g7TkAVWY984ZPwBVZuA/xckXKkIT8bBWDZJCu1hPyeg==",
+      "sha512": "NTwcJybrtXRw0xbFTIecEgHLkXEPkeqaLIzqwaW5cM9+/+gFAWtOlIp84PNQokDZuTP6gmBSkcgvVIHmOHWvpg==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -14333,12 +14249,12 @@
         "ref/MonoTouch10/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/ce72484c58e34726940faa6053a25f25.psmdcp",
+        "package/services/metadata/core-properties/e1a6a5568ba64d7a97ddb80d1776db3f.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Net.WebHeaderCollection/4.0.0": {
-      "sha512": "ek0QBZbx7sBTgrHnT1SpLp7ZO/FIIZoLPzdJ9+zt+qZt68KII+W1MmXjDG2kUm9c1GSAqCZML2DAnjyUAOo4/w==",
+      "sha512": "svwOalT10Rauv0TRbXNGgVnDYBiOzOhupGr8239WnSeLYuc+vecGe/AA+3inwz7ORjq8h9i2NgJXrMdmSwdliw==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -14365,12 +14281,12 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/798be8ad87da4c478813172e49a4a055.psmdcp",
+        "package/services/metadata/core-properties/ed8819470ca1454d93527272a1cf1a96.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Numerics.Vectors/4.1.0": {
-      "sha512": "w8MekzAwKjeNC0iqxIYvaZDk3CbcLnhIFbWN2/Wnf5DLWTvk311W4ugDekBQB8jUmCeCd9R+uxLAijntiPDKUg==",
+      "sha512": "u2UKYZi0Pb1bptFfAgpCtWfKDwUDeHYqH6MF6ucLBexVf27EQofvVGb0nd234j/BoBgw7axWBrBkpXHs+3/rjg==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -14387,23 +14303,23 @@
         "ref/MonoTouch10/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/b12ef1293e654c7fae889eceeb1319b4.psmdcp",
+        "package/services/metadata/core-properties/688cf1251c2b4f95b0bca5d3b32cfe93.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Numerics.Vectors.WindowsRuntime/4.0.0": {
-      "sha512": "F6vkmpDdJWVe3oiyzE0k5cIh6YfUgnouFWtUJIGttMEfVJc8S4qJI+JHrhwAHWs6UKcdp8drlL2gAbH/amc3Tg==",
+      "sha512": "biadOiVMG60jm7AF8yVSChml+g+UCoH9wbmOfM3KaPUzngJTeIM+vM/xZVb/mwrIRjVt0w1qHrdtCSQLd3YEFg==",
       "type": "Package",
       "files": [
         "_rels/.rels",
         "System.Numerics.Vectors.WindowsRuntime.nuspec",
         "lib/dotnet/System.Numerics.Vectors.WindowsRuntime.dll",
-        "package/services/metadata/core-properties/fe62a237f1e94d3da8f7cdf547fd0e4e.psmdcp",
+        "package/services/metadata/core-properties/0e73532a29484971ab92872da9640c64.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.ObjectModel/4.0.10": {
-      "sha512": "rU0Yk1ENLvIrJdd0AAoIylmZU4RA+5K3xF6Xkui0UnQpfHFGCksVwi3WkI3b/LXXfT971oYs35C3rUuriD09lg==",
+      "sha512": "+Jup7p7Lmgogi0LMG7XgxhT+QMK42dYyVak3eu4pu3wdcjAUpxQEP+k8pr5b8wSI1io2m/BdBaty5P6g70Ls6Q==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -14430,12 +14346,12 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/abf28e891b7745c1947b84682d4c5a13.psmdcp",
+        "package/services/metadata/core-properties/97ab30bbb4d7499aa2089f52f87a0944.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Private.DataContractSerialization/4.0.0": {
-      "sha512": "tXCwHl1yAUejj3Uo/QRYAT55m09OwedsAqwkLIKBCuF0tUpPUavVxcT1u8MaMCcFDQBuAThNVOpTnaS1qhZmjA==",
+      "sha512": "t7S03eHSX+SF4DsgSU/CRQ4aWfwzLpxvVQYGx6E4rGMdSbYlJVrOo3iKRAwn39ZErwmN0ZE1Xy+BTkdWCiRyPw==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -14446,12 +14362,12 @@
         "ref/netcore50/_._",
         "runtimes/win8-aot/lib/netcore50/System.Private.DataContractSerialization.dll",
         "runtime.json",
-        "package/services/metadata/core-properties/0a489f3355c34f3ea67d4a40b054f3bb.psmdcp",
+        "package/services/metadata/core-properties/ac3128c59c674df4b0d07982e6da09fb.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Private.Networking/4.0.0": {
-      "sha512": "FRKMtXMHjhJue/ux1Lmj/Gn3pfkAc/TNXPpsfX1fWLlFH/suLFylAuCqc83EAJaU10/i40tGDw1+pelMD+W/Lw==",
+      "sha512": "DT1hErv0h9meIbnKfP8gB3w9ppbj9WPt7wCLoyNupAUtkjOd+NTUnSs9A9NLKp8wrW02OIByRdTnjde85l+ArA==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -14460,12 +14376,12 @@
         "lib/DNXCore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "package/services/metadata/core-properties/28cf7e3606b04d7facbc42dd2ae32a35.psmdcp",
+        "package/services/metadata/core-properties/82bed6f453194edb9e9f1907b3a72299.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Private.ServiceModel/4.0.0": {
-      "sha512": "+F9GvA7xYA0j9ZxdfQDPWNogA+5i33ATaQAo33nHspMb8tALUALyQMzZnfb9PdXa/oKBpa9puMoZCVds2pR3nA==",
+      "sha512": "0WgTVgy3KJ9w8FlgGQmbhyRLzCay1Zm98ZYeCu0Hde6Ti3qg6ANmvmdzQjI7KXNIUWn8jCWEmmreOlA4zEAEAg==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -14474,12 +14390,12 @@
         "lib/DNXCore50/System.Private.ServiceModel.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "package/services/metadata/core-properties/41c5c63ed32a475ba301001579fa23fe.psmdcp",
+        "package/services/metadata/core-properties/e079841ce3944004a1d41f3cb8cac5dc.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Private.Uri/4.0.0": {
-      "sha512": "9RjLyM3bRiPNyHFv0GCn/OQXYG3CI1PBdut6FC7xGnzuLDr0XrI21HA9iZVXuURfrFLjp8moKFoVPUxqx29L6w==",
+      "sha512": "YuFPYdodhSivvkhbyiYRKpQCnXqHqWxrYYjufG3hbMXPtkDgzgDmrR59K78whcST9OLAUF7V4ugA+f1B1e2dBQ==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -14489,12 +14405,12 @@
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
         "runtimes/win8-aot/lib/netcore50/System.Private.Uri.dll",
-        "package/services/metadata/core-properties/40ac16f2842f44148a62af51bc06c2e5.psmdcp",
+        "package/services/metadata/core-properties/430c21d95fe04aeb898446a2340fddd4.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Reflection/4.0.10": {
-      "sha512": "b6VhktNkFmVfd7ykoaAh4iQfc5DnbR8TEtPYFNGLAqagj7oKtoVdOJZ6vMgQeEQ3Kl5oEs+iC2oEDhRFZJfnLg==",
+      "sha512": "Y1bIbgmm9pqfa1QgpGwAm7hFR7ConRZc+7gMA1yYje8sRheB3MClbqUfa771/CbT//1dNRqTWTVGzYgTH3qcjg==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -14523,12 +14439,12 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/010581211bc442b3bbd8480f841263df.psmdcp",
+        "package/services/metadata/core-properties/36e481d0241d400282ecb27cb0ccc450.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Reflection.Context/4.0.0": {
-      "sha512": "6fGKFYmDqWiRS7H+tzgYtQZuWzIsTK8xdB9Fa1JpMsWIxGQTqmI7WjnAvucdBmAaG9FwTLQRheDWlcBXbJgvvA==",
+      "sha512": "qPKeWLdlIdZIzK4Q1b+TqCuLUxllw/fcQttQIjNFAJKmoD/xzsv0vBaXFPNdAuSmikaUndhsh/DIwp3uJNqGyg==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -14551,12 +14467,12 @@
         "ref/win8/_._",
         "ref/netcore50/System.Reflection.Context.dll",
         "ref/netcore50/System.Reflection.Context.xml",
-        "package/services/metadata/core-properties/a390b5f05eba4c939203149ed4eb3e1a.psmdcp",
+        "package/services/metadata/core-properties/74033787840d4aae975dd0d67066dd89.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Reflection.DispatchProxy/4.0.0": {
-      "sha512": "2byRd8+k5I0HyCJaA8hzz5NrJ3c9hxRbKpzdUgPcqnA86HxKdvzSSDGfDq+6U2BzVCSD5NKywC9GGX74OTZboA==",
+      "sha512": "Peg4Fc97C/yPFsUyfPV88Dr0e6k1BQCG+PAC+szxxUlPokhv5StlRBNM01JLuoFZeV/VgSJ4pDMXsgaFc9HbYg==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -14585,12 +14501,12 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "package/services/metadata/core-properties/c2a58040d1744864a9de720f8bbf5117.psmdcp",
+        "package/services/metadata/core-properties/b16a6d61e3e1472e88dfe650d0e5aaee.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Reflection.Emit/4.0.0": {
-      "sha512": "Sr0jcW7tOD+kT2B6oob30C0kmo+1Un/pt9Xw/lKCdeWsVULtoUMuIf2sQciJqxrVHWQW8vJYeErtvDOTpmTvzQ==",
+      "sha512": "lTDrB+gsTo3/K9NyKMQjhSfc2gDxepjge7R+EsPT94lbQSNlnOZYvK49RalA8AAtCx+HjcBZgIp2N2aepPyMaA==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -14614,12 +14530,12 @@
         "ref/MonoAndroid10/_._",
         "ref/net45/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/d14088cd80924522851059901fbcf65e.psmdcp",
+        "package/services/metadata/core-properties/d25e8bc32cbe4b38b2a75b589ce9214d.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Reflection.Emit.ILGeneration/4.0.0": {
-      "sha512": "BED90hkcpXPJK0EuoBTeXAzskou6qbcogcl6AtIse1REBt7H8eXtc71BXtEeLGS6RustiL3fF7hkPmuF7cDQIw==",
+      "sha512": "DmMIAsXldaPfkqGNlUJgSmW2Gz3uVoZoXWGibDo9JuqmsUsIFeMat4E/AJf9kBqDAqNZCPSIr9cBl54w4b7ofQ==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -14641,12 +14557,12 @@
         "ref/dotnet/es/System.Reflection.Emit.ILGeneration.xml",
         "ref/net45/_._",
         "ref/wp80/_._",
-        "package/services/metadata/core-properties/c03e6e9347b146a08f9d9ced691d836b.psmdcp",
+        "package/services/metadata/core-properties/2c73bb843f884e7e89221485e19e74a3.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Reflection.Emit.Lightweight/4.0.0": {
-      "sha512": "Hahs1OpbuzkxrX3XgAtajSqZmNtyWbbZmxRIvuEBpnTCpyiXcSjt+HaSuKUX+nRvYPYvfXk/DANQawvonXl0sQ==",
+      "sha512": "UU4uDLjUyyll8sHE4eIX/TxBTuzDVHhvCC4LMh+5bVfwaVINpEsNOFdpMwjHX5bUXYqQcVHxWDdz+niQfwNSBQ==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -14668,12 +14584,12 @@
         "ref/dotnet/es/System.Reflection.Emit.Lightweight.xml",
         "ref/net45/_._",
         "ref/wp80/_._",
-        "package/services/metadata/core-properties/675d9e6e7df04390a55fd7a8ab6c7401.psmdcp",
+        "package/services/metadata/core-properties/18703fc0ff284d8180cc243d366d8b6b.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Reflection.Extensions/4.0.0": {
-      "sha512": "aO0St/fkDUnr0kYjln8Aotyp7N6KedUpVHDNdt/tZZ22P+kAtlQoYDnAw3Teo/SawpYZWLQ+3k54/ZlPU9344g==",
+      "sha512": "dVesN19ilrW2BcJuDwRQsl8pMdkeb49TMwBqFdYOzE6rYvQFasIH9eB5xYrNWdYtcL8uPHSNzzBgYvpq0P5mrA==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -14702,12 +14618,12 @@
         "ref/netcore50/System.Reflection.Extensions.xml",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/f4b9e7e1c50b469387a759d0178c734a.psmdcp",
+        "package/services/metadata/core-properties/c3c66a9aa35748dcb404fce57ff53b4f.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Reflection.Metadata/1.0.22": {
-      "sha512": "XNMokIyQboIdGHa3B+6RNcyiyUa61/9HQiHXTr/x2Kbbo3BFXxp9DVUbxUIi20vMina5C9c6+fyOgLR71z7tQw==",
+      "sha512": "55hu1gODZ1qsqEnXPUgkMMD3M/e7c3D0GHKv9rpqGC/s+oIAMdPGy96N40hAlhqPI1QakX2v5qi7Y+vc8uOcWw==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -14716,12 +14632,12 @@
         "lib/dotnet/System.Reflection.Metadata.xml",
         "lib/portable-net45+win8/System.Reflection.Metadata.xml",
         "lib/portable-net45+win8/System.Reflection.Metadata.dll",
-        "package/services/metadata/core-properties/562676ccb1914d8499c9d0fa8d0fc4e9.psmdcp",
+        "package/services/metadata/core-properties/26da3ca698eb4e3f906307c042063c9b.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Reflection.Primitives/4.0.0": {
-      "sha512": "D3jA6wJvvurlD8zilI4ylxtVIvh8X8P4SC3pXsrspjkQIDKaBdSDVtNas81pe/5x9PZOhPrf3VklqL+daFg9bA==",
+      "sha512": "MxktthPaFUHrk2Dw4FJbWc9/PrtwBbCvXv8FJjfGYL1jCyvbyUEBzOSmCqygIOK8ibNBHOUr1sn+3dMli48bdg==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -14750,12 +14666,12 @@
         "ref/netcore50/System.Reflection.Primitives.xml",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/8e0e125413764723a29feaed5b58d31b.psmdcp",
+        "package/services/metadata/core-properties/6213080fda2e4dc9aa5b8af4305af659.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Reflection.TypeExtensions/4.0.0": {
-      "sha512": "OX4v3qhzUH+rzglUFxocjT1YaKWeq+JCgryFwli9hnCCIJdaqaVEdQ/29xQMBIp+CcNLryB2HSbCSxP3JHHt2A==",
+      "sha512": "8o1LeG23SeIut80IC6WXCar++mpWBl9l/zXUBzyg8oHwuoL6XloM+RNhGJcn4ARiOpNE1CIQg9c3MZU0slS0SQ==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -14784,12 +14700,12 @@
         "ref/MonoTouch10/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/7073f566ec8c4d43aa683e2ab3ab2ac4.psmdcp",
+        "package/services/metadata/core-properties/fdbf60947abe44df841351c32bb1045c.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Resources.ResourceManager/4.0.0": {
-      "sha512": "V1R7VU+nA6TV/ozfAXkg77c6PE6y0fTDFeUgLCdn2e4fdlbMYpNefCBxQC70F2H71Bd9/2iuWuP/IRyN6nohhA==",
+      "sha512": "kncnPdZsHyPztthxbAW0piheDzOsdFAGGhR1PlYRrw36eFvsqBDOoFhrr8MRbIvEUABkXRJ7y/VA/KMjw7szLQ==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -14818,12 +14734,12 @@
         "ref/netcore50/System.Resources.ResourceManager.xml",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/3cb35b0681d04a9aba820a2e9972bf96.psmdcp",
+        "package/services/metadata/core-properties/9694c547aeaa495ea66f22d0d9056fe2.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Runtime/4.0.20": {
-      "sha512": "lk2daP5LCI/iUJPs+FcZLCBey2Ppe/tzEZ/Atb6IzbGL36+IEpvl//K6rNN+wFGq17TAmJAz9lJjAcUiJvN6yQ==",
+      "sha512": "HwPEacV5LIFX+CtDJHZ2Vg4Jb/IrWR0DtWkng+id/l1FYxezXQVLAfk1HMq7MEI9/lLlHuwny6G2+lDTIBnrpA==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -14852,12 +14768,12 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/e91eca3dfe4442a6a995ebb7093d180e.psmdcp",
+        "package/services/metadata/core-properties/802e8d5028f44bb189b41d8a071471d6.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Runtime.Extensions/4.0.10": {
-      "sha512": "nJ5bAGB0PFD1cK9Xvj1omwXgwoVJfhfSHsH1JGL0VCH2IizUlmIZWksQ/XZbxu6mZ62vKbE0ZWrlhDds3ZjTWQ==",
+      "sha512": "nHxlbn5i2euL8q7aVVRsTMvjDXFDJs0T+x/DmrA4Musa2OUCg6XkGZOSaWP6H1xvpGJ5YxPnll0Oh/+aqrzvCA==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -14886,12 +14802,12 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/aab851eea4404ff49d6b79ba077d728d.psmdcp",
+        "package/services/metadata/core-properties/d2a54219c54549858eac36b72da44fda.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Runtime.Handles/4.0.0": {
-      "sha512": "sd8o4KQsKkdLmjJPycvEYpwLfa8NuYOVDqDVzU72CxXOFiSD0Oi1+EsmReeI1VA6UTpHGF7l9V8DCKXHervrpQ==",
+      "sha512": "c1rc5UcWuNDVJqtrwY+pmj1tPvMIkZCzsBQ6pw0+7vcsaZJcLdSUze1NqvuywC/NPbpp/VrDHP9LmiCqUvfpxA==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -14920,12 +14836,12 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/ceb38b93222e45b39fc80acbb46ee814.psmdcp",
+        "package/services/metadata/core-properties/592e3c746bbc4c7b8a4a521c3ded0e10.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Runtime.InteropServices/4.0.20": {
-      "sha512": "grTr0P9/f0US5V0YqeOq8yeBsXxEpmG999E0xasYvhmhUGPCTDYCCT/T3Ng92f04wz66uPW2hP9eYdhVN2AgtQ==",
+      "sha512": "dZfOloo6zRiANnaVnlxuVh2HzHpwD5f9cczA59LrnMuOeVpeyWIjidIup2rhLf/jFg256vLGBlrsO7C7CNqX9w==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -14954,12 +14870,12 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/81f03decd30a4765816f34c93f027029.psmdcp",
+        "package/services/metadata/core-properties/898e1e6a1c0b409a82b768c91c667be1.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Runtime.InteropServices.WindowsRuntime/4.0.0": {
-      "sha512": "hV7B7kMqgyuObrG2pR9ASxVJwNkBWHnCltXLV1MmfFzyUxWBXDWrpxLMhE/BMSRAaVPDK3Wwcfzw1jYFQpLDAw==",
+      "sha512": "xkybQrVaIouYpr8iIQJwCa20aiCsemWkGCHOZqZFlwHqD2LVSJSVNsyoPO+CzGZf0XJ2n7FJhlD56+KfAd1erA==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -14987,12 +14903,12 @@
         "ref/netcore50/System.Runtime.InteropServices.WindowsRuntime.xml",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/d69c4938f1974f52aa378310ab468e18.psmdcp",
+        "package/services/metadata/core-properties/4e4d74ad5bc94ed2af26e9bdc371dcd3.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Runtime.Numerics/4.0.0": {
-      "sha512": "FQ8Bu8IPNARW+wT7gHVpXJeWt6mircbALTlf+IwyXkzjRSggJujIdxZjwlKGgqCas5eNCmEgDqOz2O6pVZFs4A==",
+      "sha512": "UfF9gc4eVIjCC1B8IrLHV3qhmlGE4kX54nzJxTRTciD//1hyWhieEEqGMrREwbEjl86LMMLWfKpZr68Sj27NmA==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -15018,12 +14934,12 @@
         "ref/netcore50/System.Runtime.Numerics.dll",
         "ref/netcore50/System.Runtime.Numerics.xml",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/62255f0fea1149a3a883d73d7d84f48c.psmdcp",
+        "package/services/metadata/core-properties/47de96118c08428cb2fddf9ce1ddda69.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Runtime.Serialization.Json/4.0.0": {
-      "sha512": "FBiYSldS03hMWaADQPDBPVgCgx5anoiBkDCr/2rpX/wcjQaWeqMD1gzLe+gCvoJKfSkAnp7OBRh0X0adnjvIDQ==",
+      "sha512": "4SavMJo9JU3LZiSq2eeV4A4eK1hHU0P/N1WyekL2raRKphcc9947fIgON6Cg/9szRi/9h7jOcz9E6IM5hV5Ndw==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -15052,12 +14968,12 @@
         "ref/netcore50/System.Runtime.Serialization.Json.xml",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/f8532195e9b4462ba7d61febba016a0c.psmdcp",
+        "package/services/metadata/core-properties/24d38f4074f644b1a834783a6ae89f7c.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Runtime.Serialization.Primitives/4.0.10": {
-      "sha512": "W3k5VVDyCzyZNgykAayL0HcgBCikUbLtfiB7JNKqEgTHwQsVn+2OCCCu871WYN/eutYqRuIohWdk1duqy0Wvsg==",
+      "sha512": "3dWbReL+64TC4JjKZibmmdgRDnIhKxGTm6ydbueyprlPuOUL9FNNwzalNwSPmN9aP9/UMpblA0f/1nETcZfQ5A==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -15084,12 +15000,12 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/d1ea219fed2f4734a922fbb3677f4a2e.psmdcp",
+        "package/services/metadata/core-properties/d3318f0bd10b4b5080a635731bcbc059.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Runtime.Serialization.Xml/4.0.10": {
-      "sha512": "/uiSaVzf9WSVxpfR1WxsW+CC26Xuct+RvwHf7GBWnn7N8oihObtzPaEWi0mKZuUUjiMGc6iZkjWsoTz8Lr8jvA==",
+      "sha512": "EMvlvX1nChEG3e+h7JZ3/EK5jQh/dNSpZMvij4mxMjHyLACRDsyiou/IrOCUtQABpJjp2wtmJtgc5cA3IJMR2g==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -15118,12 +15034,12 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/e1652b20613c45579a2f742ac62e467e.psmdcp",
+        "package/services/metadata/core-properties/dd6587eae3724e70991c3079f6257faa.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Runtime.WindowsRuntime/4.0.10": {
-      "sha512": "sp2SURw8EA4sCqD27X3Y7l4mLn0MWRBEO+9B6kItp0SXwmmOUtBGAwoZYAemQMgtKcd8diPStMF8m/I4rpaUyA==",
+      "sha512": "XWcaNMDUJSkvIu3aoU2jeCYwptegDTPvN1m/EbT5myh7P5v3MAkoROMqsIYgNmwzX9z9GfRxkWMixKyJqudCEA==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -15147,12 +15063,12 @@
         "ref/netcore50/System.Runtime.WindowsRuntime.dll",
         "ref/netcore50/System.Runtime.WindowsRuntime.xml",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/03311433d01e48889c7d914542ef31a4.psmdcp",
+        "package/services/metadata/core-properties/aead15d2882b422d9d9ca090fb0e0a6c.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Runtime.WindowsRuntime.UI.Xaml/4.0.0": {
-      "sha512": "KtNpa1MbMIvRVIAjyruqeDpCtfJaYzHeEjvKLdhAEsf9zQFlZsn8Svsb/1m39tlUzKVxuccgbBYywB02hAMWiw==",
+      "sha512": "G07nPeBDtZ8+Q0GvI2iFLuWxf1YdkO12BEFXaaFT/nlg99wB63BoAdMDZ2doQZNKtpozN5lhehMxHLVaWnZuhg==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -15175,12 +15091,12 @@
         "ref/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll",
         "ref/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.xml",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/e61f1d3910bc4268b0e73c6b2aabd879.psmdcp",
+        "package/services/metadata/core-properties/2f82e0186d8d4f2593d6ce82983aa2c1.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Security.Claims/4.0.0": {
-      "sha512": "BAuhEuJHxliUFEnPD3ohARzTA3s1WnhB78gUlY0iTrxHS9OlfYYJGhXMQuMJGvvpUy4ZcUfBYaIf5Y7fazQVDw==",
+      "sha512": "VfM0MnRTJKjQv4/Gp5YoOegZHH9hNwxwFsYcwl38gBXhXEENbYo8iRqdqjUL/+WIiJcBtmX6Si4DJvLG539EQQ==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -15207,12 +15123,12 @@
         "ref/MonoTouch10/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/7e2fe39e39f34fbd93a2c565c44bfb11.psmdcp",
+        "package/services/metadata/core-properties/5d7557059b7642d38131ff5ab0ef51a3.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Security.Principal/4.0.0": {
-      "sha512": "xFQKpzFqijf5pjJmgGsN0kbZaKrJZXFvRM5J3VOaLrAw/0V1x4Dxt8RlXauFY/hMmI+Np9wD0rSWO1Z4VdFZ/A==",
+      "sha512": "F2RVK0oavzJLq9ggOilk5JlELowlv6sXe+V+qn1/DHZxL68JTuo0s5HYgIMHWZeYlzy0i/RWXkKR8UuKfGjrMw==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -15240,12 +15156,12 @@
         "ref/netcore50/System.Security.Principal.xml",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/6c652551d6dd442097dfc9e1e3abf6cf.psmdcp",
+        "package/services/metadata/core-properties/d2167ecb380c408c860234844cf67d48.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.ServiceModel.Duplex/4.0.0": {
-      "sha512": "UjcGSpXLf7T01JZXwb3g3hq/mLNqMoGu/6TbQJ35tYx+3Y29nK2To9mxqsp3wEh5Yjo+VRbLGn2DXg5EukAhUw==",
+      "sha512": "9xrHWt+Si5pIeSl/44CYpTTJKRIfHQrEHR9X5s+w9njCAPllvR0HSq/IdTqDL7bNpHH/pGyARJYzP2skH1oLmw==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -15269,12 +15185,12 @@
         "ref/win8/_._",
         "ref/netcore50/System.ServiceModel.Duplex.dll",
         "ref/netcore50/System.ServiceModel.Duplex.xml",
-        "package/services/metadata/core-properties/f2edd702b70244d98802f30e5663d608.psmdcp",
+        "package/services/metadata/core-properties/cf038ac1247e42ae85b95bc37d264dba.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.ServiceModel.Http/4.0.10": {
-      "sha512": "fFqDv6L0jBVH2VQ1PMnrfS88NIgWE3NcWq5giFor8V6obcdNtsj3HJsT5OgyCmnwl6AR0/z/XBpF162kr3m2NA==",
+      "sha512": "fIwcLZDBW49SWrHOyx88lzq+ADOylZD92REtpEWuv2Y6XA74AG7XcVd/YSmqaLM8dGby6sGV8j7SL8prd9p++w==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -15302,12 +15218,12 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/b914ac1b4d9642b6ba95cefd95f8925a.psmdcp",
+        "package/services/metadata/core-properties/cade0d9420704a3692b521e1e6597870.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.ServiceModel.NetTcp/4.0.0": {
-      "sha512": "P/yu3OV8THTi5x+xHSeA5C5rVOegDjDjps2HVynVXKjRrTQ2LpGF5Bo52ZNdth/Hxk+X+XECnumgAPzxmzN8YA==",
+      "sha512": "lunfsS1obMf4OtADN4sMt4ikP+faoRRAHb5bF6rFCCFqShR/pBzK+uhNih6r4Bfrz2I/LVE3cuE2hdOZ91mCyg==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -15331,12 +15247,12 @@
         "ref/win8/_._",
         "ref/netcore50/System.ServiceModel.NetTcp.dll",
         "ref/netcore50/System.ServiceModel.NetTcp.xml",
-        "package/services/metadata/core-properties/5ac811b14dd44abdaabaed5cd965ff2e.psmdcp",
+        "package/services/metadata/core-properties/e0aa9ce2e74b457bb270415c04190532.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.ServiceModel.Primitives/4.0.0": {
-      "sha512": "3qYmY9ESdBk67X3WLhw04alEyPkCQrEq/oheQIg3tZOvLEcCeO56as43YDCPMEQ8x77m9ZhbVgsp6LIO8lW3EQ==",
+      "sha512": "s3IIHBjGY2OJBJ+NE9MNAPrxDpZFoRtaIeyASr7S4utiB4XzScF5SIvnyigaoOH0XxKy0k4cvmlqrmE/AQpV/A==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -15360,12 +15276,12 @@
         "ref/win8/_._",
         "ref/netcore50/System.ServiceModel.Primitives.dll",
         "ref/netcore50/System.ServiceModel.Primitives.xml",
-        "package/services/metadata/core-properties/8d6bf1d06bda4603a4c2ac5408b42eaa.psmdcp",
+        "package/services/metadata/core-properties/a790279c1a0941a085bbac6a1b35346b.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.ServiceModel.Security/4.0.0": {
-      "sha512": "vfHPhKkH+O9CaOzZv9/Vcm5awwq9nzeIIjn02vk5XwvZebp6GnGZ7zQP3MX4ytoVumdsSE5VWbmtubR3DOb7nQ==",
+      "sha512": "yVhmsaZpzd/eQcF9lVobn7iZl7Kwy34qllKZTRnGo3X2Z1GKvp0e5WZELCVB8b5aR/TJNSF1v0X6nzALrl1Thg==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -15389,7 +15305,7 @@
         "ref/win8/_._",
         "ref/netcore50/System.ServiceModel.Security.dll",
         "ref/netcore50/System.ServiceModel.Security.xml",
-        "package/services/metadata/core-properties/8ab90a6f68e44778a803764f099c2a1b.psmdcp",
+        "package/services/metadata/core-properties/1ad3533e5ed44d90af69bde78bcdb24b.psmdcp",
         "[Content_Types].xml"
       ]
     },
@@ -15437,7 +15353,7 @@
       ]
     },
     "System.Text.Encoding/4.0.10": {
-      "sha512": "sKguvFCt3hkwos5TciYU/1KH6kjKi7UPFIIgeKHQSSuZVzVufNpoK/lSp3agPZyc3lJWVGVY6ycczhpJ4IlxIw==",
+      "sha512": "QRMAwNr44yDSOZnEFIbB3B2/wSlRwjg1Up7mLFdz95qLV6HtwJoF5IDmcPAFDhxeBIXA2xEVgQ6NF/bmz7MvFA==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -15466,12 +15382,12 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/846e6003d52f4eff9cdf1bd89e1c3463.psmdcp",
+        "package/services/metadata/core-properties/99e06dad813b4b0ea6e79635e4aeed2d.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Text.Encoding.CodePages/4.0.0": {
-      "sha512": "CbYomNYySp/7AkosCRk9sIojiqnmXOl6WZyhcwThMlKW4hmcTgFy5cvKUdDjNCPFtnCuRpz9eNDKjCmd+9R+Vw==",
+      "sha512": "G1Kac8BSZeoRkyXy8JhJ+nVR2EiEkYx9JPkyjtS55FEE9Q7+zZm9P1cO3R60TvFw7vEA5d0MvteOqaSs0wfZuA==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -15496,12 +15412,12 @@
         "ref/MonoTouch10/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/c79480cd7eab4a1b8811136cf93b4c11.psmdcp",
+        "package/services/metadata/core-properties/96df9198b75d4e57b6b39ee93e11235b.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Text.Encoding.Extensions/4.0.10": {
-      "sha512": "K8dF8EzVAjTjNu0/4MxYoRHcCl4wqLMhFLa1s9qxLqMfHlqC28R3Rr8xLhx+t6EGaycfO8lSDBdgRihng7817A==",
+      "sha512": "vmWkQnNeSYMv3Qqi1ZbAYsAaQxMM/nSWzU4I5FD1UoF0gXTKmfPy2B7Yvg+TfJruyUM4J7WnDvPjfqmiDEebcw==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -15530,12 +15446,12 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/efe8218cfb7443aab8943943362229e5.psmdcp",
+        "package/services/metadata/core-properties/b8dd74a08aa44361a3a7e7a76cc952e8.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Text.RegularExpressions/4.0.10": {
-      "sha512": "X68y/y4GCoik5VcHC1q17NXcHlfcOKTHZbw34jhiKlSD58OZzgxzzJy2/a1HRTs2Ay9/1YgFaTEPDA7sY3+99A==",
+      "sha512": "5oE4UK1/DKmfdvn6bXVs2wjGPujHHgPMQ4rIFfE6jOeokvMFqWmm6Smj/On4BLL9ePtl2a1K+1m8PN6sR0R3cQ==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -15562,12 +15478,12 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/831203f5ab894d81ab907112c232f60b.psmdcp",
+        "package/services/metadata/core-properties/31d1e1cfc3e94ad983a84849041f458e.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Threading/4.0.10": {
-      "sha512": "r0kmTbXnz3G9pagdoO1fVptT4/1cV0R4zNfuJ6KzNo6PXs+WkmIUZUGWB5NL9UWPEu8AVWvQT6f9MPCGqbOC+A==",
+      "sha512": "OlRpjfuszymCB/WrD902/k89S6GcEoJGjkP499yv7fhk89ClNTejFUn+gSAL+42BuKaV6DhbNfDEbugpzJ9sjg==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -15596,12 +15512,12 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/da8a3fc9ec0f4340bc42010c30f283de.psmdcp",
+        "package/services/metadata/core-properties/55cbec202a024564af14207d5fdbad6e.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Threading.Overlapped/4.0.0": {
-      "sha512": "S2KmzZbckZcWRkJzi5eVUKlrB39DyVsNQXteK1BIcH5xvTd3gWvrkKH9creTthEZI5b/PqmihuKLlmNHKhPfsg==",
+      "sha512": "JqybuOcjX6pE/oiQNt42RrDE0pEzts/Enx7F3SNKppl1zecJqy/6gxQGNP/w1+06Cv7/wqpTJ5nBx/ilUoBMOQ==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -15621,12 +15537,12 @@
         "ref/dotnet/zh-hans/System.Threading.Overlapped.xml",
         "ref/dotnet/es/System.Threading.Overlapped.xml",
         "ref/net46/System.Threading.Overlapped.dll",
-        "package/services/metadata/core-properties/ac0c01083f214340b03a728385bdb448.psmdcp",
+        "package/services/metadata/core-properties/8e038e1c6e934eb6b1bc029ecd09f5a9.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Threading.Tasks/4.0.10": {
-      "sha512": "5W63czaYeGMLY7z2RpAuL2g/Yp8+5EwJjdNOHwg8tcoOovA4Yo4PL4SP/dlT8JEMz4t+UYOcaOpH0892cPt8MA==",
+      "sha512": "AyPTUdGW6nvfCWOx+V83QpJOI3MPUX0CR1cG1+tREnrAhxFQRIFtbUTSTKDSxBg3Tf9/FuQJ882zAD0d025Vbw==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -15655,12 +15571,12 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/2163b143eb8c46b4a3f61659e208bab7.psmdcp",
+        "package/services/metadata/core-properties/2d44b999137446a6b6f025535c68d5c6.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Threading.Tasks.Dataflow/4.5.25": {
-      "sha512": "/fHnL6WQPnnkGqJoctya1Muw1YJR+mSABpKRfRjyzFZLEGHmgj6UsAWwF1CpwdyE3v1lb8/9eTWzPDAX249Hiw==",
+      "sha512": "ByzWsin3a67XIehKt3Nzr9cjYe7KpKWPG1JdS4uIzRpJCD5jhmeS7viebv1Ww84/hWbjitj/w8evWAeBcU9Zrg==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -15671,12 +15587,12 @@
         "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll",
         "lib/portable-net45+win8+wp8+wpa81/System.Threading.Tasks.Dataflow.XML",
         "lib/portable-net45+win8+wp8+wpa81/System.Threading.Tasks.Dataflow.dll",
-        "package/services/metadata/core-properties/e24d19499af64162959c3a0ab9dbd074.psmdcp",
+        "package/services/metadata/core-properties/5dbb2f421aa0488489fb65c68cb65b0a.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Threading.Tasks.Parallel/4.0.0": {
-      "sha512": "q8At93Cu5XJBNwvWhUQg0r/hIpWDqfklsU46gify1JOuyu5buiYS7HJBEKrtQpmGnF6HooNOaC2uGGk0o3RH2Q==",
+      "sha512": "36odC23GPM+90J43UX7T+0Yq8f2T87dDMLj0/pNJ/iLSqQLCnlPOQmoF3rEBaSc0dRLmXo1H2ez6eAjpXyJAew==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -15702,12 +15618,12 @@
         "ref/netcore50/System.Threading.Tasks.Parallel.dll",
         "ref/netcore50/System.Threading.Tasks.Parallel.xml",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/b2824c035fab43e6920d7e5848d9cea0.psmdcp",
+        "package/services/metadata/core-properties/ef7f055e7fdd43978a411750f945e415.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Threading.Timer/4.0.0": {
-      "sha512": "xnHG7WAXhBXDFbMtuVsUJ/kfQTvRCUV+JtWr8PJRatkTADIblU6dqMJ8g6tTrG9AR1Bh+oahhbK27/iJ345ZjQ==",
+      "sha512": "5UgGz7+gYFQ9V72cp0YJGr2cXycEzRz4owRAfzvFO5IvC1mWb99+jw/0qeu++m8oEnNgpzHMaiTn6pomCf864w==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -15734,12 +15650,12 @@
         "ref/netcore50/System.Threading.Timer.dll",
         "ref/netcore50/System.Threading.Timer.xml",
         "ref/wpa81/_._",
-        "package/services/metadata/core-properties/8cda0093b709467aa92d29f2d471bbc4.psmdcp",
+        "package/services/metadata/core-properties/46f0e60d6ab644148c6118b536eccecf.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Xml.ReaderWriter/4.0.10": {
-      "sha512": "8yktKJIKKE3ZrLxjwbxYOJ/daDLKcro3Qt4MDB6yCEv7/9iS4sphbj0vCSHtlrGlQKrKPXnLjPYVAA+JnFX/7g==",
+      "sha512": "sf5+y7HK/zl6FhuoWOXWUCxRZaAr8sdIFXkBbz0fy52UD2YDDmW2hgo7juSL0tHCFfDEgx/EMMJk2UJemhNveg==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -15766,12 +15682,12 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/f97fce435c684b1384b2a048cdc7eab4.psmdcp",
+        "package/services/metadata/core-properties/d91fcc706e71450fa842017251387dea.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Xml.XDocument/4.0.10": {
-      "sha512": "POFwEeE5gme26KxzZd5o8zhm8RJ5GhM5ar+DV5LPTPoCwzN48Tm8Qb0BRmwCOWVzi4KGLaR4waL1XAvH2W0v7g==",
+      "sha512": "KFOoas7lYIR5ywRF93eI1RJmQNrZrerV7pAFuSahRvDAmq4WnovI3m0GVOttXQpnxySHNOPhwCZVhc/PXJPmKw==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -15798,12 +15714,12 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/431d06b4e24c4087bb72252aca15f0cd.psmdcp",
+        "package/services/metadata/core-properties/b3ee51c19456402abb9d1b2dd2a8e10f.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Xml.XmlDocument/4.0.0": {
-      "sha512": "MRecp7CM/GcCyfpWEoZlBK61M5MvJSVjqYitebN2GQiJXeRfvSNkDWwockYQtMEmhPxcEFDfPJEfhZ+wv3wF1A==",
+      "sha512": "AgRrKj6UGQF9m+B3vP5gd8ED4syMIeQO0Y9XkuIFWAZVoYi/+uVv0jLQw1ZvRh4aiEyQMsJbMfLgheINWNLjUg==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -15830,12 +15746,12 @@
         "ref/MonoTouch10/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "package/services/metadata/core-properties/d5077e230a0745b1ada6784b8bf644d0.psmdcp",
+        "package/services/metadata/core-properties/07688b9175f04a0e904fcb1d6112f564.psmdcp",
         "[Content_Types].xml"
       ]
     },
     "System.Xml.XmlSerializer/4.0.10": {
-      "sha512": "XvaP/8Q5ocL16xlTsOaJtCs7Z00wEXrA/X2E2XLknpbQ1ykd8/IVaye0woROjPeOR5DLzOfUf5Ti086toNhcLg==",
+      "sha512": "XJBwDtM3i29T2UDMtxSY2e+hWSD2+cEuqTrxvuKKWeY38DcvT6dFKin5qYpGW8fuhqnP6ndUWYF2WtUi+QCl6A==",
       "type": "Package",
       "files": [
         "_rels/.rels",
@@ -15865,7 +15781,7 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "package/services/metadata/core-properties/c80d56868865446d9ee122fad8e0fdb9.psmdcp",
+        "package/services/metadata/core-properties/da8e7adafa1545449bd2c0bb174dfb44.psmdcp",
         "[Content_Types].xml"
       ]
     },


### PR DESCRIPTION
This solves the problem of running the app locally and accidentally messing up your entire pictures library. We will need to update the Hackster post to instruct people, in the camera setup step, to point the camera FTP path to "\Users\DefaultAccount\Pictures\securitysystem-cameradrop", and in the initial device setup steps, to use powershell to create the directory as that new path as well
