### PR TITLE
Adding EnvironmentSettings.cs to csproj file

### DIFF
--- a/SecuritySystemUWP/SecuritySystemUWP/SecuritySystemUWP.csproj
+++ b/SecuritySystemUWP/SecuritySystemUWP/SecuritySystemUWP.csproj
@@ -99,6 +99,7 @@
     <Compile Include="Camera\UsbCamera.cs" />
     <Compile Include="Camera\CameraFactory.cs" />
     <Compile Include="Controller.cs" />
+    <Compile Include="EnvironmentSettings.cs" />
     <Compile Include="MotionSensor.cs" />
     <Compile Include="MainPage.xaml.cs">
       <DependentUpon>MainPage.xaml</DependentUpon>


### PR DESCRIPTION
Build break fix.  New file, EnvironmentSettings.cs, was not included in csproj file.
