### PR TITLE
Fix app crash

### DIFF
--- a/SecuritySystemUWP/SecuritySystemUWP/AllJoynManager.cs
+++ b/SecuritySystemUWP/SecuritySystemUWP/AllJoynManager.cs
@@ -55,7 +55,8 @@ namespace SecuritySystemUWP
             var images = await this.dropFolder.GetFilesAsync();
             var orderedImages = images.OrderByDescending(x => x.DateCreated);
             var file = orderedImages.FirstOrDefault();
-            if (null != file && file.Name != this.newestImage.Name)
+
+            if ((null == this.newestImage) || (null != file && file.Name != this.newestImage.Name))
             {
                 this.newestImage = file;
                 this.producer.EmitLastCaptureFileNameChanged();

--- a/SecuritySystemUWP/SecuritySystemUWP/AllJoynManager.cs
+++ b/SecuritySystemUWP/SecuritySystemUWP/AllJoynManager.cs
@@ -56,7 +56,7 @@ namespace SecuritySystemUWP
             var orderedImages = images.OrderByDescending(x => x.DateCreated);
             var file = orderedImages.FirstOrDefault();
 
-            if ((null == this.newestImage) || (null != file && file.Name != this.newestImage.Name))
+            if ((null != file) && (null == this.newestImage || file.Name != this.newestImage.Name))
             {
                 this.newestImage = file;
                 this.producer.EmitLastCaptureFileNameChanged();


### PR DESCRIPTION
fix issue where sending a test image from D-link camera for the first time can crash app. If there isn't a file there on app launch, accept the first new file to show up without attempting to compare it to the previous file, since that object is null.