### PR TITLE
Crashing bug fix when app enters suspend state.  Unhandled exception in TelemetryHelper.AddCommonProperties().

### DIFF
--- a/SecuritySystemUWP/SecuritySystemUWP/App.xaml.cs
+++ b/SecuritySystemUWP/SecuritySystemUWP/App.xaml.cs
@@ -160,7 +160,7 @@ namespace SecuritySystemUWP
             GlobalStopwatch.Stop();
             TelemetryHelper.TrackMetric("AppRuntime", GlobalStopwatch.Elapsed.TotalMilliseconds);
 
-            var metrics = new Dictionary<string, string> { { "userAlias", App.Controller.XmlSettings.MicrosoftAlias }, { "appRuntime", GlobalStopwatch.Elapsed.TotalMilliseconds.ToString() } };
+            var metrics = new Dictionary<string, string> {{ "appRuntime", GlobalStopwatch.Elapsed.TotalMilliseconds.ToString() } };
             TelemetryHelper.TrackEvent("UserRuntime", metrics);
 
             var deferral = e.SuspendingOperation.GetDeferral();

--- a/SecuritySystemUWP/SecuritySystemUWP/MainPage.xaml.cs
+++ b/SecuritySystemUWP/SecuritySystemUWP/MainPage.xaml.cs
@@ -7,6 +7,8 @@ using System.Threading.Tasks;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Navigation;
+using Windows.Networking.Connectivity;
+using Windows.UI.Core;
 
 namespace SecuritySystemUWP
 {
@@ -15,24 +17,59 @@ namespace SecuritySystemUWP
     /// </summary>
     public sealed partial class MainPage : Page
     {
+        private CoreDispatcher _MainPageDispatcher = null;
+        
+
         public MainPage()
         {
-            string ipAddress = "";
-            string instructions = "";
-
             this.InitializeComponent();
 
-            // get device environment info and display it in UI
-            deviceNameValueTextBlock.Text = EnvironmentSettings.GetDeviceName();
-            ipAddress = EnvironmentSettings.GetIPAddress();
-            ipAddressValueTextBlock.Text = ipAddress;
+            _MainPageDispatcher = Window.Current.Dispatcher;
+
+            // network status change event
+            NetworkInformation.NetworkStatusChanged += NetworkInformation_NetworkStatusChanged;
+
+            // get static device environment info and display it in UI           
             appVersionValueTextBlock.Text = EnvironmentSettings.GetAppVersion();
             OSVersionValueTextBlock.Text = EnvironmentSettings.GetOSVersion();
 
-            // instructions text with ip address
-            instructions = "Setup Instructions: To configure this security system please go to URL http://" + ipAddress + ":8000 on a browser.";
-            instructionsTextBlock.Text = instructions;
+            UpdateNetworkInfo();
 
+        }
+
+        /// <summary>
+        /// On network status change update network info and display on main page
+        /// </summary>
+        /// <param name="sender"></param>
+        private async void NetworkInformation_NetworkStatusChanged(object sender)
+        {
+            await _MainPageDispatcher.RunAsync(CoreDispatcherPriority.Low, () =>
+            {
+                UpdateNetworkInfo();
+            });
+        }
+
+        /// <summary>
+        /// Get dynamic network information about the device and display it
+        /// </summary>
+        private void UpdateNetworkInfo()
+        {
+            string ipAddress = EnvironmentSettings.GetIPAddress();
+            string instructions = "";
+            // check if ip address is valid
+            if (ipAddress == "0.0.0.0")
+            {
+                ipAddress = "Invalid IP Address: 0.0.0.0";
+                instructions = "Setup Instructions: Please ensure your device has a valid ip address first.";
+            }
+            else {
+                instructions = "Setup Instructions: To configure this security system please go to URL http://" + ipAddress + ":8000 on a browser.";
+            }
+
+            // update UI
+            deviceNameValueTextBlock.Text = EnvironmentSettings.GetDeviceName();
+            ipAddressValueTextBlock.Text = ipAddress;
+            instructionsTextBlock.Text = instructions;
         }
     }
 }

--- a/SecuritySystemUWP/SecuritySystemUWP/TelemetryHelper.cs
+++ b/SecuritySystemUWP/SecuritySystemUWP/TelemetryHelper.cs
@@ -22,14 +22,28 @@ namespace SecuritySystemUWP
         /// <param name="properties">original properties to add to</param>
         private static void AddCommonProperties(ref IDictionary<string, string> properties)
         {
-            
-            properties.Add("Custom_AppVersion", EnvironmentSettings.GetAppVersion());
-            properties.Add("Custom_OSVersion", EnvironmentSettings.GetOSVersion());
-
+            // add common properties as long as they don't already exist in the original properties passed in
+            if (!properties.ContainsKey("Custom_AppVersion"))
+            {
+                properties.Add("Custom_AppVersion", EnvironmentSettings.GetAppVersion());
+            }
+            if (!properties.ContainsKey("Custom_OSVersion"))
+            {
+                properties.Add("Custom_OSVersion", EnvironmentSettings.GetOSVersion());
+            }
 #if MS_INTERNAL_ONLY // Do not send this app insights telemetry data for external customers. Microsoft only.
-            properties.Add("userAlias", App.Controller.XmlSettings.MicrosoftAlias);
-            properties.Add("Custom_DeviceName", EnvironmentSettings.GetDeviceName());
-            properties.Add("Custom_IPAddress", EnvironmentSettings.GetIPAddress());
+            if (!properties.ContainsKey("userAlias"))
+            {
+                properties.Add("userAlias", App.Controller.XmlSettings.MicrosoftAlias);
+            }
+            if (!properties.ContainsKey("Custom_DeviceName"))
+            {
+                properties.Add("Custom_DeviceName", EnvironmentSettings.GetDeviceName());
+            }
+            if (!properties.ContainsKey("Custom_IPAddress"))
+            {
+                properties.Add("Custom_IPAddress", EnvironmentSettings.GetIPAddress());
+            }
 #endif
         }
 


### PR DESCRIPTION
App crashes on OnSuspend() state in TelemetryHelper.AddCommonProperties().  This is because the 'userAlias' is added to the properties twice which throws an InvalidArguement Exception.  Removed the duplicate entry and also fixed AddCommonProperties() to be more robust.